### PR TITLE
Fixed potential test failure due to nondeterminism in the order of elements in hash map used in RequestTest.testQueryParams

### DIFF
--- a/src/test/java/spark/RequestTest.java
+++ b/src/test/java/spark/RequestTest.java
@@ -468,7 +468,7 @@ public class RequestTest {
     @Test
     public void testQueryParams() {
 
-        Map<String, String[]> params = new HashMap<>();
+        Map<String, String[]> params = new LinkedHashMap<>();
         params.put("sort", new String[]{"asc"});
         params.put("items", new String[]{"10"});
 


### PR DESCRIPTION
This pull request addresses the flakiness in the `RequestTest.testQueryParams` test by resolving the non-deterministic behavior identified using the NonDex tool. The root cause of the flakiness was the non-deterministic order of elements in the `params` hash map. The test can be found [here](https://github.com/perwendel/spark/blob/master/src/test/java/spark/RequestTest.java).

- How was the non-deterministic behavior identified in the test?
The non-deterministic behavior in the test was identified by using an open-source research tool named [NonDex](https://github.com/TestingResearchIllinois/NonDex) which is responsible for finding and diagnosing non-deterministic runtime exceptions in Java programs.

- Why does the test fail?
The test assumes that the order of elements in the `params` hash map will be the same as the order in which the elements were added to the hash map. However, the order of elements in a hash map is non deterministic, it can be shuffled sometimes due to which the assertion might fail. As a result, the test might fail sometimes.

- How I fixed the test?
I fixed the test by replacing the `HashMap` with a `LinkedHashMap`. This ensures that the order of elements in `params` is the same as the order in which the elements were added to it.
 
- Output from NonDex:
```
[INFO] Running spark.RequestTest
[Thread-1] INFO org.eclipse.jetty.util.log - Logging initialized @983ms to org.eclipse.jetty.util.log.Slf4jLog
[Thread-1] INFO spark.embeddedserver.jetty.EmbeddedJettyServer - == Spark has ignited ...
[Thread-1] INFO spark.embeddedserver.jetty.EmbeddedJettyServer - >> Listening on 0.0.0.0:4567
[Thread-1] INFO org.eclipse.jetty.server.Server - jetty-9.4.48.v20220622; built: 2022-06-21T20:42:25.880Z; git: 6b67c5719d1f4371b33655ff2d047d24e171e49a; jvm 11.0.21+9-post-Ubuntu-0ubuntu120.04
[Thread-1] INFO org.eclipse.jetty.server.session - DefaultSessionIdManager workerName=node0
[Thread-1] INFO org.eclipse.jetty.server.session - No SessionScavenger set, using defaults
[Thread-1] INFO org.eclipse.jetty.server.session - node0 Scavenging every 660000ms
[Thread-1] INFO org.eclipse.jetty.server.AbstractConnector - Started ServerConnector@593c7e7d{HTTP/1.1, (http/1.1)}{0.0.0.0:4567}
[Thread-1] INFO org.eclipse.jetty.server.Server - Started @1103ms
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.704 s <<< FAILURE! - in spark.RequestTest
[ERROR] testQueryParams(spark.RequestTest)  Time elapsed: 0.7 s  <<< FAILURE!
org.junit.internal.ArrayComparisonFailure: Should return the query parameter names: arrays first differed at element [0]; expected:<[sort]> but was:<[items]>
	at spark.RequestTest.testQueryParams(RequestTest.java:479)
Caused by: org.junit.ComparisonFailure: expected:<[sort]> but was:<[items]>
	at spark.RequestTest.testQueryParams(RequestTest.java:479)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   RequestTest.testQueryParams:479 Should return the query parameter names: arrays first differed at element [0]; expected:<[sort]> but was:<[items]>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
INFO: Surefire failed when running tests for gJHPXK0QG1QJwo8I6WNi5T5CqS09uTvMMWkJ7HPKMNo=
[INFO] NonDex SUMMARY:
[INFO] *********
[INFO] mvn nondex:nondex  -DnondexFilter='.*' -DnondexMode=FULL -DnondexSeed=933178 -DnondexStart=0 -DnondexEnd=9223372036854775807 -DnondexPrintstack=false -DnondexDir="/home/shetty5/project/fixes/spark/.nondex" -DnondexJarDir="/home/shetty5/project/fixes/spark/.nondex" -DnondexExecid=FkpNSIk7LIPSMRFVHBTpa92+BT7dWCXfDiZA1amS9Oc= -DnondexLogging=CONFIG
```

You can run the following command to run the test using the NonDex tool:

```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=spark.RequestTest#testQueryParams
```

<br>
Test Environment:

```
java version 11.0.20.1
Apache Maven 3.6.3
```

Let me know if this fix is acceptable

Thank you!